### PR TITLE
Add console alarm manager application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Aplikacja budzika
 
-Prosta aplikacja konsolowa do zarządzania wieloma budzikami. Pozwala dodawać, usuwać,
-wyświetlać oraz uruchamiać harmonogram budzików zapisanych w pliku JSON.
+Prosta aplikacja do zarządzania wieloma budzikami. Oprócz interfejsu konsolowego
+zawiera także panel graficzny oparty na Tkinterze, który pozwala dodawać, usuwać,
+aktywować i podglądać zaplanowane budziki zapisane w pliku JSON.
 
 ## Instalacja i uruchomienie
 
@@ -15,6 +16,19 @@ python -m alarms.cli list
 python -m alarms.cli preview
 python -m alarms.cli run
 ```
+
+### Interfejs graficzny
+
+Aby uruchomić panel graficzny (wymaga biblioteki Tkinter dostępnej w standardowej
+dystrybucji Pythona), wykonaj:
+
+```bash
+python -m alarms.gui
+```
+
+W oknie aplikacji znajdziesz listę istniejących budzików, formularz dodawania
+nowych oraz przyciski do podglądu najbliższych powiadomień i uruchomienia
+harmonogramu w tle.
 
 Domyślnie dane zapisywane są w pliku `~/.alarms.json`. Można wskazać własną ścieżkę za
 pomocą przełącznika `--storage` (np. podczas testowania).

--- a/README.md
+++ b/README.md
@@ -20,18 +20,35 @@ python -m alarms.cli run
 ### Interfejs graficzny
 
 Aby uruchomić panel graficzny (wymaga biblioteki Tkinter dostępnej w standardowej
-dystrybucji Pythona), wykonaj:
+dystrybucji Pythona), wystarczy:
 
 ```bash
-python -m alarms.gui
+python -m alarms
 ```
 
 W oknie aplikacji znajdziesz listę istniejących budzików, formularz dodawania
 nowych oraz przyciski do podglądu najbliższych powiadomień i uruchomienia
 harmonogramu w tle.
 
-Domyślnie dane zapisywane są w pliku `~/.alarms.json`. Można wskazać własną ścieżkę za
-pomocą przełącznika `--storage` (np. podczas testowania).
+Domyślnie dane zapisywane są w pliku `~/.alarms.json`. Jeśli chcesz wskazać
+inną lokalizację pliku, użyj przełącznika `--storage` przed nazwą trybu, na
+przykład:
+
+```bash
+python -m alarms --storage /ścieżka/do/pliku.json
+```
+
+### Tryb CLI z poziomu `python -m alarms`
+
+Jeżeli wolisz pozostać przy wersji konsolowej, możesz uruchomić wszystkie
+dotychczasowe komendy przez ten sam punkt wejścia:
+
+```bash
+python -m alarms cli add 07:30 --label "Pobudka"
+python -m alarms cli list
+python -m alarms cli preview
+python -m alarms --storage /tmp/alarms.json cli run
+```
 
 ## Harmonogram
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# pr-bne
+# Aplikacja budzika
+
+Prosta aplikacja konsolowa do zarządzania wieloma budzikami. Pozwala dodawać, usuwać,
+wyświetlać oraz uruchamiać harmonogram budzików zapisanych w pliku JSON.
+
+## Instalacja i uruchomienie
+
+Aplikacja korzysta wyłącznie ze standardowej biblioteki Pythona. Aby sprawdzić
+możliwości, uruchom polecenia z poziomu katalogu repozytorium:
+
+```bash
+python -m alarms.cli add 07:30 --label "Pobudka"
+python -m alarms.cli add 21:00 --label "Przygotuj kolację" --days pon śro pia
+python -m alarms.cli list
+python -m alarms.cli preview
+python -m alarms.cli run
+```
+
+Domyślnie dane zapisywane są w pliku `~/.alarms.json`. Można wskazać własną ścieżkę za
+pomocą przełącznika `--storage` (np. podczas testowania).
+
+## Harmonogram
+
+Polecenie `run` uruchamia prosty harmonogram, który co pewien czas sprawdza najbliższe
+budziki i wyświetla powiadomienie w terminalu. Aby zakończyć działanie programu,
+naciśnij `Ctrl+C`.
+
+## Testy
+
+Do uruchomienia testów służy:
+
+```bash
+pytest
+```

--- a/alarms/__init__.py
+++ b/alarms/__init__.py
@@ -1,0 +1,7 @@
+"""Simple alarm application package."""
+
+from .models import Alarm
+from .manager import AlarmManager
+from .scheduler import AlarmScheduler
+
+__all__ = ["Alarm", "AlarmManager", "AlarmScheduler"]

--- a/alarms/__init__.py
+++ b/alarms/__init__.py
@@ -4,4 +4,9 @@ from .models import Alarm
 from .manager import AlarmManager
 from .scheduler import AlarmScheduler
 
-__all__ = ["Alarm", "AlarmManager", "AlarmScheduler"]
+try:  # pragma: no cover - tkinter may be unavailable in some environments
+    from .gui import AlarmApp
+except Exception:  # pragma: no cover - fallback for headless setups
+    AlarmApp = None  # type: ignore[assignment]
+
+__all__ = ["Alarm", "AlarmManager", "AlarmScheduler", "AlarmApp"]

--- a/alarms/__main__.py
+++ b/alarms/__main__.py
@@ -1,0 +1,61 @@
+"""Convenient entrypoint to run the alarms package."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+from . import cli as cli_module
+from .gui import launch
+from .manager import AlarmManager
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Uruchom aplikację alarmów w trybie graficznym (domyślnie) lub CLI.",
+        add_help=True,
+    )
+    parser.add_argument(
+        "--storage",
+        type=Path,
+        default=None,
+        help="Ścieżka do pliku z budzikami (domyślnie ~/.alarms.json)",
+    )
+    parser.add_argument(
+        "mode",
+        nargs="?",
+        choices=["gui", "cli"],
+        default="gui",
+        help="Wybierz tryb: gui lub cli (domyślnie gui)",
+    )
+    parser.add_argument(
+        "cli_args",
+        nargs=argparse.REMAINDER,
+        help="Pozostałe argumenty przekazywane do trybu CLI, np. add 07:30 --label ...",
+    )
+    return parser
+
+
+def _normalize_remainder(args: List[str]) -> List[str]:
+    # argparse.REMAINDER pozostawia separator "--"; usuń go, jeśli jest pierwszym elementem.
+    if args and args[0] == "--":
+        return args[1:]
+    return args
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.mode == "gui":
+        manager = AlarmManager(storage_path=args.storage)
+        launch(manager=manager)
+        return 0
+
+    cli_args = _normalize_remainder(list(args.cli_args))
+    return cli_module.main(cli_args, storage_path=args.storage)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/alarms/cli.py
+++ b/alarms/cli.py
@@ -115,10 +115,10 @@ def format_alarm_row(alarm) -> str:
     return f"#{alarm.alarm_id} | {alarm.time_str} | {schedule} | {status} | {alarm.label}"
 
 
-def main(argv: Iterable[str] | None = None) -> int:
+def main(argv: Iterable[str] | None = None, *, storage_path=None) -> int:
     parser = build_parser()
     args = parser.parse_args(list(argv) if argv is not None else None)
-    manager = AlarmManager(storage_path=args.storage)
+    manager = AlarmManager(storage_path=storage_path or args.storage)
 
     if args.command == "add":
         days = parse_weekdays(args.days)

--- a/alarms/cli.py
+++ b/alarms/cli.py
@@ -1,0 +1,175 @@
+"""Command line interface for managing alarms."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+from .manager import AlarmManager
+from .scheduler import AlarmScheduler, preview_schedule
+
+
+def parse_weekdays(values: Iterable[str]) -> List[int]:
+    mapping = {
+        "mon": 0,
+        "monday": 0,
+        "pon": 0,
+        "tue": 1,
+        "tuesday": 1,
+        "wto": 1,
+        "wed": 2,
+        "wednesday": 2,
+        "śro": 2,
+        "thu": 3,
+        "thursday": 3,
+        "czw": 3,
+        "fri": 4,
+        "friday": 4,
+        "pia": 4,
+        "sat": 5,
+        "saturday": 5,
+        "sob": 5,
+        "sun": 6,
+        "sunday": 6,
+        "nie": 6,
+    }
+    days: List[int] = []
+    for value in values:
+        key = value.strip().lower()
+        if key.isdigit():
+            days.append(int(key))
+            continue
+        if key not in mapping:
+            raise argparse.ArgumentTypeError(
+                f"Nieznany dzień tygodnia: {value}. Użyj nazw (pon, tue, ...) lub numerów 0-6."
+            )
+        days.append(mapping[key])
+    return days
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Prosty menedżer budzików")
+    parser.add_argument(
+        "--storage",
+        type=Path,
+        default=None,
+        help="Ścieżka do pliku z zapisanymi budzikami (domyślnie ~/.alarms.json)",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    add_parser = subparsers.add_parser("add", help="Dodaj nowy budzik")
+    add_parser.add_argument("time", help="Godzina w formacie HH:MM")
+    add_parser.add_argument("--label", default="Alarm", help="Etykieta budzika")
+    add_parser.add_argument(
+        "--days",
+        nargs="*",
+        default=(),
+        help="Dni tygodnia (np. pon, wed, 0-6). Brak oznacza codziennie.",
+    )
+
+    list_parser = subparsers.add_parser("list", help="Wyświetl istniejące budziki")
+
+    remove_parser = subparsers.add_parser("remove", help="Usuń budzik po identyfikatorze")
+    remove_parser.add_argument("alarm_id", help="Identyfikator budzika")
+
+    toggle_parser = subparsers.add_parser("toggle", help="Włącz lub wyłącz budzik")
+    toggle_parser.add_argument("alarm_id", help="Identyfikator budzika")
+    toggle_parser.add_argument(
+        "--enable",
+        dest="enabled",
+        action="store_true",
+        default=None,
+        help="Włącz budzik",
+    )
+    toggle_parser.add_argument(
+        "--disable",
+        dest="enabled",
+        action="store_false",
+        help="Wyłącz budzik",
+    )
+
+    run_parser = subparsers.add_parser("run", help="Uruchom harmonogram budzików")
+    run_parser.add_argument(
+        "--refresh",
+        type=float,
+        default=30.0,
+        help="Jak często sprawdzać harmonogram (sekundy)",
+    )
+    run_parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Zakończ po pierwszym wyzwoleniu budzika",
+    )
+
+    subparsers.add_parser("preview", help="Pokaż najbliższe aktywacje budzików")
+
+    return parser
+
+
+def format_alarm_row(alarm) -> str:
+    status = "Włączony" if alarm.enabled else "Wyłączony"
+    schedule = alarm.describe_schedule()
+    return f"#{alarm.alarm_id} | {alarm.time_str} | {schedule} | {status} | {alarm.label}"
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    manager = AlarmManager(storage_path=args.storage)
+
+    if args.command == "add":
+        days = parse_weekdays(args.days)
+        alarm = manager.add_alarm(time_str=args.time, label=args.label, repeat_days=days)
+        print("Dodano budzik:")
+        print(format_alarm_row(alarm))
+        return 0
+
+    if args.command == "list":
+        alarms = manager.list_alarms()
+        if not alarms:
+            print("Brak zapisanych budzików.")
+            return 0
+        for alarm in alarms:
+            print(format_alarm_row(alarm))
+        return 0
+
+    if args.command == "remove":
+        removed = manager.remove_alarm(args.alarm_id)
+        if removed:
+            print("Usunięto budzik.")
+            return 0
+        print("Nie znaleziono budzika o podanym identyfikatorze.")
+        return 1
+
+    if args.command == "toggle":
+        if args.enabled is None:
+            parser.error("Użyj --enable lub --disable aby określić stan budzika.")
+        updated = manager.toggle_alarm(args.alarm_id, args.enabled)
+        if updated:
+            print("Zmieniono stan budzika.")
+            return 0
+        print("Nie znaleziono budzika.")
+        return 1
+
+    if args.command == "run":
+        scheduler = AlarmScheduler(manager, refresh_interval=args.refresh)
+        scheduler.run(once=args.once)
+        return 0
+
+    if args.command == "preview":
+        text = preview_schedule(manager.list_alarms())
+        if text:
+            print(text)
+        else:
+            print("Brak aktywnych budzików.")
+        return 0
+
+    parser.error("Nieznane polecenie")
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/alarms/gui.py
+++ b/alarms/gui.py
@@ -1,0 +1,245 @@
+"""Simple Tkinter-based graphical interface for managing alarms."""
+
+from __future__ import annotations
+
+import threading
+import tkinter as tk
+from datetime import datetime
+from queue import Empty, Queue
+from tkinter import messagebox, ttk
+from typing import List, Optional
+
+from .manager import AlarmManager
+from .models import Alarm
+from .scheduler import AlarmScheduler, preview_schedule
+
+
+WEEKDAY_NAMES = [
+    "Poniedziałek",
+    "Wtorek",
+    "Środa",
+    "Czwartek",
+    "Piątek",
+    "Sobota",
+    "Niedziela",
+]
+
+
+class AlarmApp:
+    """Graphical application that wraps :class:`AlarmManager`."""
+
+    def __init__(self, manager: Optional[AlarmManager] = None) -> None:
+        self.manager = manager or AlarmManager()
+        self.root = tk.Tk()
+        self.root.title("Alarmy")
+        self.root.geometry("640x480")
+
+        self._scheduler: Optional[AlarmScheduler] = None
+        self._scheduler_thread: Optional[threading.Thread] = None
+        self._notification_queue: "Queue[str]" = Queue()
+
+        self._build_layout()
+        self.refresh_list()
+        self._schedule_notification_poll()
+        self.root.protocol("WM_DELETE_WINDOW", self._on_close)
+
+    # ------------------------------------------------------------------
+    # Layout
+    def _build_layout(self) -> None:
+        main = ttk.Frame(self.root, padding=12)
+        main.pack(fill=tk.BOTH, expand=True)
+
+        # Alarm list
+        tree_frame = ttk.LabelFrame(main, text="Zdefiniowane budziki")
+        tree_frame.pack(fill=tk.BOTH, expand=True)
+
+        columns = ("time", "label", "days", "enabled")
+        self.tree = ttk.Treeview(tree_frame, columns=columns, show="headings", height=8)
+        self.tree.heading("time", text="Godzina")
+        self.tree.heading("label", text="Etykieta")
+        self.tree.heading("days", text="Harmonogram")
+        self.tree.heading("enabled", text="Aktywny")
+        self.tree.column("time", width=80, anchor=tk.CENTER)
+        self.tree.column("label", width=200, anchor=tk.W)
+        self.tree.column("days", width=200, anchor=tk.W)
+        self.tree.column("enabled", width=80, anchor=tk.CENTER)
+        self.tree.pack(fill=tk.BOTH, expand=True, side=tk.LEFT)
+
+        scrollbar = ttk.Scrollbar(tree_frame, orient=tk.VERTICAL, command=self.tree.yview)
+        self.tree.configure(yscrollcommand=scrollbar.set)
+        scrollbar.pack(fill=tk.Y, side=tk.RIGHT)
+
+        # Form for new alarm
+        form = ttk.LabelFrame(main, text="Dodaj nowy budzik", padding=12)
+        form.pack(fill=tk.X, pady=(12, 0))
+
+        ttk.Label(form, text="Godzina (HH:MM)").grid(row=0, column=0, sticky=tk.W)
+        self.time_var = tk.StringVar()
+        ttk.Entry(form, textvariable=self.time_var, width=10).grid(row=1, column=0, sticky=tk.W)
+
+        ttk.Label(form, text="Etykieta").grid(row=0, column=1, sticky=tk.W, padx=(12, 0))
+        self.label_var = tk.StringVar(value="Nowy budzik")
+        ttk.Entry(form, textvariable=self.label_var, width=30).grid(row=1, column=1, sticky=tk.W, padx=(12, 0))
+
+        self.enabled_var = tk.BooleanVar(value=True)
+        ttk.Checkbutton(form, text="Aktywny", variable=self.enabled_var).grid(row=1, column=2, padx=(12, 0))
+
+        days_frame = ttk.Frame(form)
+        days_frame.grid(row=2, column=0, columnspan=3, pady=(12, 0), sticky=tk.W)
+        ttk.Label(days_frame, text="Dni powtórzeń:").pack(side=tk.LEFT)
+
+        self.day_vars: List[tk.BooleanVar] = []
+        for index, name in enumerate(WEEKDAY_NAMES):
+            var = tk.BooleanVar(value=False)
+            check = ttk.Checkbutton(days_frame, text=name[:3], variable=var)
+            check.pack(side=tk.LEFT, padx=3)
+            self.day_vars.append(var)
+
+        button_frame = ttk.Frame(form)
+        button_frame.grid(row=3, column=0, columnspan=3, pady=(12, 0), sticky=tk.W)
+        ttk.Button(button_frame, text="Dodaj budzik", command=self.add_alarm).pack(side=tk.LEFT)
+        ttk.Button(button_frame, text="Usuń zaznaczony", command=self.remove_selected).pack(side=tk.LEFT, padx=6)
+        ttk.Button(button_frame, text="Aktywuj/Dezaktywuj", command=self.toggle_selected).pack(side=tk.LEFT)
+        ttk.Button(button_frame, text="Odśwież", command=self.refresh_list).pack(side=tk.LEFT, padx=6)
+
+        scheduler_frame = ttk.LabelFrame(main, text="Harmonogram", padding=12)
+        scheduler_frame.pack(fill=tk.X, pady=(12, 0))
+
+        ttk.Button(
+            scheduler_frame,
+            text="Podgląd najbliższych",
+            command=self.preview_alarms,
+        ).pack(side=tk.LEFT)
+
+        ttk.Button(
+            scheduler_frame,
+            text="Uruchom harmonogram",
+            command=self.start_scheduler,
+        ).pack(side=tk.LEFT, padx=6)
+
+        ttk.Button(
+            scheduler_frame,
+            text="Zatrzymaj harmonogram",
+            command=self.stop_scheduler,
+        ).pack(side=tk.LEFT)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    def _collect_selected_days(self) -> List[int]:
+        return [index for index, var in enumerate(self.day_vars) if var.get()]
+
+    def _set_tree_item(self, alarm: Alarm) -> None:
+        schedule = alarm.describe_schedule()
+        values = (alarm.time_str, alarm.label, schedule, "Tak" if alarm.enabled else "Nie")
+        self.tree.insert("", tk.END, iid=alarm.alarm_id, values=values)
+
+    def refresh_list(self) -> None:
+        for item in self.tree.get_children():
+            self.tree.delete(item)
+        for alarm in self.manager.list_alarms():
+            self._set_tree_item(alarm)
+
+    # ------------------------------------------------------------------
+    # Button callbacks
+    def add_alarm(self) -> None:
+        time_value = self.time_var.get().strip()
+        label = self.label_var.get().strip() or "Alarm"
+        repeat_days = self._collect_selected_days()
+        try:
+            alarm = self.manager.add_alarm(time_value, label=label, repeat_days=repeat_days, enabled=self.enabled_var.get())
+        except ValueError as exc:
+            messagebox.showerror("Błąd", str(exc))
+            return
+        self._set_tree_item(alarm)
+        messagebox.showinfo("Sukces", "Dodano nowy budzik.")
+
+    def remove_selected(self) -> None:
+        selection = self.tree.selection()
+        if not selection:
+            messagebox.showwarning("Brak wyboru", "Zaznacz budzik do usunięcia.")
+            return
+        removed_any = False
+        for item in selection:
+            alarm_id = item
+            if self.manager.remove_alarm(alarm_id):
+                self.tree.delete(item)
+                removed_any = True
+        if removed_any:
+            messagebox.showinfo("Sukces", "Usunięto wybrane budziki.")
+
+    def toggle_selected(self) -> None:
+        selection = self.tree.selection()
+        if not selection:
+            messagebox.showwarning("Brak wyboru", "Zaznacz budzik do przełączenia.")
+            return
+        for item in selection:
+            alarm_id = item
+            alarm = self.manager.get_alarm(alarm_id)
+            if not alarm:
+                continue
+            self.manager.toggle_alarm(alarm_id, not alarm.enabled)
+        self.refresh_list()
+
+    def preview_alarms(self) -> None:
+        upcoming = preview_schedule(self.manager.list_alarms(), count=5)
+        if not upcoming:
+            messagebox.showinfo("Podgląd", "Brak aktywnych budzików.")
+            return
+        messagebox.showinfo("Podgląd", upcoming)
+
+    # ------------------------------------------------------------------
+    # Scheduler handling
+    def start_scheduler(self) -> None:
+        if self._scheduler_thread and self._scheduler_thread.is_alive():
+            messagebox.showinfo("Harmonogram", "Harmonogram już działa.")
+            return
+
+        def notifier(alarm: Alarm, trigger_time: datetime) -> None:
+            formatted = f"{trigger_time:%Y-%m-%d %H:%M} — {alarm.label}"
+            self._notification_queue.put(formatted)
+
+        self._scheduler = AlarmScheduler(self.manager, notifier=notifier)
+        self._scheduler_thread = threading.Thread(target=self._scheduler.run, daemon=True)
+        self._scheduler_thread.start()
+        messagebox.showinfo("Harmonogram", "Uruchomiono harmonogram w tle.")
+
+    def stop_scheduler(self) -> None:
+        if self._scheduler:
+            self._scheduler.stop()
+        if self._scheduler_thread and self._scheduler_thread.is_alive():
+            self._scheduler_thread.join(timeout=0.5)
+        self._scheduler_thread = None
+        self._scheduler = None
+        messagebox.showinfo("Harmonogram", "Harmonogram zatrzymany.")
+
+    def _schedule_notification_poll(self) -> None:
+        try:
+            while True:
+                message = self._notification_queue.get_nowait()
+                messagebox.showinfo("Budzik", message)
+        except Empty:
+            pass
+        finally:
+            self.root.after(500, self._schedule_notification_poll)
+
+    # ------------------------------------------------------------------
+    def _on_close(self) -> None:
+        if self._scheduler:
+            self._scheduler.stop()
+        self.root.destroy()
+
+    def run(self) -> None:
+        """Start the Tkinter main loop."""
+
+        self.root.mainloop()
+
+
+def launch(manager: Optional[AlarmManager] = None) -> None:
+    """Convenience helper to start the GUI."""
+
+    app = AlarmApp(manager=manager)
+    app.run()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage
+    launch()

--- a/alarms/manager.py
+++ b/alarms/manager.py
@@ -1,0 +1,90 @@
+"""High level API for interacting with alarms."""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from .models import Alarm, validate_days
+
+
+class AlarmManager:
+    """Stores and retrieves alarms from a JSON file."""
+
+    def __init__(self, storage_path: Optional[os.PathLike[str]] = None) -> None:
+        self.storage_path = Path(storage_path or Path.home() / ".alarms.json")
+        self._alarms: List[Alarm] = []
+        self._loaded = False
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _ensure_loaded(self) -> None:
+        if self._loaded:
+            return
+        if self.storage_path.exists():
+            with self.storage_path.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+            self._alarms = [Alarm.from_dict(item) for item in data]
+        else:
+            self._alarms = []
+        self._loaded = True
+
+    def _save(self) -> None:
+        payload = [alarm.to_dict() for alarm in self._alarms]
+        temp_path = self.storage_path.with_suffix(".tmp")
+        with temp_path.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2)
+        temp_path.replace(self.storage_path)
+
+    # ------------------------------------------------------------------
+    # Public operations
+    def list_alarms(self) -> List[Alarm]:
+        self._ensure_loaded()
+        return list(self._alarms)
+
+    def add_alarm(
+        self,
+        time_str: str,
+        label: str = "Alarm",
+        repeat_days: Optional[Iterable[int]] = None,
+        enabled: bool = True,
+    ) -> Alarm:
+        self._ensure_loaded()
+        repeat_days = validate_days(repeat_days or [])
+        alarm = Alarm(time_str=time_str, label=label, repeat_days=repeat_days, enabled=enabled)
+        alarm_id = alarm.alarm_id or uuid.uuid4().hex
+        alarm = alarm.with_id(alarm_id)
+        self._alarms.append(alarm)
+        self._save()
+        return alarm
+
+    def remove_alarm(self, alarm_id: str) -> bool:
+        self._ensure_loaded()
+        before = len(self._alarms)
+        self._alarms = [alarm for alarm in self._alarms if alarm.alarm_id != alarm_id]
+        removed = len(self._alarms) != before
+        if removed:
+            self._save()
+        return removed
+
+    def toggle_alarm(self, alarm_id: str, enabled: bool) -> bool:
+        self._ensure_loaded()
+        updated = False
+        for alarm in self._alarms:
+            if alarm.alarm_id == alarm_id:
+                alarm.enabled = enabled
+                updated = True
+                break
+        if updated:
+            self._save()
+        return updated
+
+    def get_alarm(self, alarm_id: str) -> Optional[Alarm]:
+        self._ensure_loaded()
+        for alarm in self._alarms:
+            if alarm.alarm_id == alarm_id:
+                return alarm
+        return None

--- a/alarms/models.py
+++ b/alarms/models.py
@@ -1,0 +1,106 @@
+"""Data models for the alarm application."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, time, timedelta
+from typing import Iterable, List, Optional, Sequence, Set
+
+
+def _parse_time(value: str) -> time:
+    try:
+        hour_str, minute_str = value.split(":", 1)
+        hour = int(hour_str)
+        minute = int(minute_str)
+        if not (0 <= hour < 24 and 0 <= minute < 60):
+            raise ValueError
+    except ValueError as exc:  # pragma: no cover - defensive branch
+        raise ValueError(
+            "Time must be in HH:MM format using 24 hour clock"
+        ) from exc
+    return time(hour=hour, minute=minute)
+
+
+@dataclass
+class Alarm:
+    """Represents a single alarm configuration."""
+
+    time_str: str
+    label: str = "Alarm"
+    repeat_days: Sequence[int] = field(default_factory=list)
+    enabled: bool = True
+    alarm_id: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        self.time: time = _parse_time(self.time_str)
+        self.repeat_days = tuple(sorted(set(self.repeat_days)))
+
+    def with_id(self, alarm_id: str) -> "Alarm":
+        clone = Alarm(
+            time_str=self.time_str,
+            label=self.label,
+            repeat_days=self.repeat_days,
+            enabled=self.enabled,
+            alarm_id=alarm_id,
+        )
+        return clone
+
+    def to_dict(self) -> dict:
+        return {
+            "alarm_id": self.alarm_id,
+            "time": self.time_str,
+            "label": self.label,
+            "repeat_days": list(self.repeat_days),
+            "enabled": self.enabled,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict) -> "Alarm":
+        return cls(
+            time_str=payload["time"],
+            label=payload.get("label", "Alarm"),
+            repeat_days=payload.get("repeat_days", ()),
+            enabled=payload.get("enabled", True),
+            alarm_id=payload.get("alarm_id"),
+        )
+
+    def next_trigger(self, reference: Optional[datetime] = None) -> Optional[datetime]:
+        if not self.enabled:
+            return None
+
+        reference = reference or datetime.now()
+        days: Set[int] = set(self.repeat_days)
+
+        for offset in range(8):
+            candidate_date = reference.date() + timedelta(days=offset)
+            if days and candidate_date.weekday() not in days:
+                continue
+            candidate_dt = datetime.combine(candidate_date, self.time)
+            if candidate_dt >= reference:
+                return candidate_dt
+        return None
+
+    def matches_day(self, weekday: int) -> bool:
+        return not self.repeat_days or weekday in self.repeat_days
+
+    def describe_schedule(self) -> str:
+        if not self.repeat_days:
+            return "Codziennie"
+        names = [
+            "Pon",
+            "Wto",
+            "Śro",
+            "Czw",
+            "Pią",
+            "Sob",
+            "Nie",
+        ]
+        return ", ".join(names[day] for day in self.repeat_days)
+
+
+def validate_days(days: Iterable[int]) -> List[int]:
+    unique_days = sorted(set(days))
+    for day in unique_days:
+        if day < 0 or day > 6:
+            raise ValueError("Days of week must be between 0 (Monday) and 6 (Sunday)")
+    return unique_days

--- a/alarms/scheduler.py
+++ b/alarms/scheduler.py
@@ -1,0 +1,86 @@
+"""Runtime scheduler that waits for alarms and notifies the user."""
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from datetime import datetime
+from typing import Callable, Iterable, Optional
+
+from .manager import AlarmManager
+from .models import Alarm
+
+NotificationCallback = Callable[[Alarm, datetime], None]
+
+
+def default_notifier(alarm: Alarm, trigger_time: datetime) -> None:
+    message = f"\n🔔 {trigger_time:%Y-%m-%d %H:%M} - {alarm.label} (#{alarm.alarm_id})"
+    print(message)
+    print("Naciśnij Ctrl+C aby przerwać działanie budzika.")
+
+
+class AlarmScheduler:
+    """Continuously monitors alarms and fires them when the time comes."""
+
+    def __init__(
+        self,
+        manager: AlarmManager,
+        notifier: NotificationCallback = default_notifier,
+        refresh_interval: float = 30.0,
+    ) -> None:
+        self.manager = manager
+        self.notifier = notifier
+        self.refresh_interval = max(1.0, refresh_interval)
+        self._stop_event = threading.Event()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+    def run(self, *, once: bool = False) -> None:
+        try:
+            while not self._stop_event.is_set():
+                now = datetime.now()
+                alarms = [
+                    (alarm.next_trigger(now), alarm)
+                    for alarm in self.manager.list_alarms()
+                    if alarm.enabled
+                ]
+                alarms = [(trigger, alarm) for trigger, alarm in alarms if trigger]
+
+                if not alarms:
+                    print("Brak aktywnych budzików. Dodaj nowy budzik aby rozpocząć.")
+                    if once:
+                        return
+                    time.sleep(self.refresh_interval)
+                    continue
+
+                next_trigger, next_alarm = min(alarms, key=lambda pair: pair[0])
+                wait_seconds = max(0.0, (next_trigger - datetime.now()).total_seconds())
+                if wait_seconds > 0:
+                    sleep_time = min(wait_seconds, self.refresh_interval)
+                    self._stop_event.wait(timeout=sleep_time)
+                    continue
+
+                self.notifier(next_alarm, next_trigger)
+                if once:
+                    return
+                time.sleep(1)
+        except KeyboardInterrupt:
+            print("\nPrzerwano działanie budzika.")
+            sys.exit(0)
+
+
+def preview_schedule(alarms: Iterable[Alarm], count: int = 5) -> str:
+    upcoming = []
+    reference = datetime.now()
+    for alarm in alarms:
+        trigger = alarm.next_trigger(reference)
+        if trigger:
+            upcoming.append((trigger, alarm))
+    upcoming.sort(key=lambda pair: pair[0])
+
+    lines = []
+    for trigger, alarm in upcoming[:count]:
+        lines.append(f"{trigger:%Y-%m-%d %H:%M} — {alarm.label} (#{alarm.alarm_id})")
+    return "\n".join(lines)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,17 @@
+import json
+from alarms.__main__ import _normalize_remainder, main
+
+
+def test_main_cli_uses_provided_storage(tmp_path):
+    storage = tmp_path / "alarms.json"
+    exit_code = main(["--storage", str(storage), "cli", "add", "08:00", "--label", "Test"])
+    assert exit_code == 0
+
+    with storage.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    assert data[0]["label"] == "Test"
+
+
+def test_normalize_remainder_strips_separator():
+    assert _normalize_remainder(["--", "preview"]) == ["preview"]
+    assert _normalize_remainder(["preview"]) == ["preview"]

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+from alarms.manager import AlarmManager
+
+
+def test_add_and_list_alarms(tmp_path: Path):
+    storage = tmp_path / "alarms.json"
+    manager = AlarmManager(storage_path=storage)
+    manager.add_alarm("08:15", label="Pobudka")
+    manager.add_alarm("21:30", label="Przypomnienie", repeat_days=[0, 2])
+
+    alarms = manager.list_alarms()
+    assert len(alarms) == 2
+    assert alarms[0].label == "Pobudka"
+    assert alarms[1].repeat_days == (0, 2)
+
+
+def test_remove_alarm(tmp_path: Path):
+    storage = tmp_path / "alarms.json"
+    manager = AlarmManager(storage_path=storage)
+    alarm = manager.add_alarm("08:15")
+    assert manager.remove_alarm(alarm.alarm_id)
+    assert not manager.list_alarms()
+
+
+def test_toggle_alarm(tmp_path: Path):
+    storage = tmp_path / "alarms.json"
+    manager = AlarmManager(storage_path=storage)
+    alarm = manager.add_alarm("08:15")
+    assert manager.toggle_alarm(alarm.alarm_id, False)
+    stored = manager.get_alarm(alarm.alarm_id)
+    assert stored is not None
+    assert stored.enabled is False

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+
+from alarms.models import Alarm
+
+
+def test_alarm_next_trigger_daily_future_time():
+    reference = datetime(2024, 1, 1, 8, 0)
+    alarm = Alarm(time_str="09:30", label="Poranny alarm")
+    trigger = alarm.next_trigger(reference)
+    assert trigger == datetime(2024, 1, 1, 9, 30)
+
+
+def test_alarm_next_trigger_daily_next_day():
+    reference = datetime(2024, 1, 1, 10, 0)
+    alarm = Alarm(time_str="09:30")
+    trigger = alarm.next_trigger(reference)
+    assert trigger == datetime(2024, 1, 2, 9, 30)
+
+
+def test_alarm_next_trigger_specific_days():
+    reference = datetime(2024, 1, 1, 8, 0)  # Monday
+    alarm = Alarm(time_str="07:00", repeat_days=[2])  # Wednesday
+    trigger = alarm.next_trigger(reference)
+    assert trigger == datetime(2024, 1, 3, 7, 0)
+
+
+def test_alarm_disabled_has_no_trigger():
+    reference = datetime(2024, 1, 1, 8, 0)
+    alarm = Alarm(time_str="07:00", enabled=False)
+    assert alarm.next_trigger(reference) is None
+
+
+def test_alarm_describe_schedule():
+    alarm = Alarm(time_str="07:00", repeat_days=[0, 2, 4])
+    assert alarm.describe_schedule() == "Pon, Śro, Pią"


### PR DESCRIPTION
## Summary
- add a reusable `Alarm` model with next-trigger calculations and schedule descriptions
- implement a JSON-backed `AlarmManager` along with a CLI for adding, listing, removing and running alarms
- provide a runtime scheduler plus preview output and accompanying documentation
- cover the new functionality with pytest unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d54725c3f88332b2bf5e08251dd51a