### PR TITLE
Add 3D browser game prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# pr-bne
+# Mini gra 3D (Three.js)
+
+Prosta, przeglądarkowa gra 3D napisana w Three.js. Sterujesz neonową kostką, która zbiera lewitujące kryształki na futurystycznym placu. Liczy się wynik zdobyty w ciągu 60 sekund.
+
+## Jak uruchomić
+
+1. Otwórz plik `index.html` w przeglądarce (najlepiej przez prosty serwer plików, np. VS Code Live Server lub `python -m http.server`).
+2. Aktywuj okno i steruj: `W/A/S/D` lub strzałki poruszają się po planie, `spacja` skacze.
+3. Zbieraj kryształki, aby zwiększać wynik. Po upływie czasu możesz odświeżyć stronę i zagrać ponownie.
+
+## Struktura
+
+- `index.html` – warstwa UI oraz osadzenie płótna WebGL.
+- `src/main.js` – logika gry, inicjalizacja sceny i pętla animacji Three.js.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,158 @@
+<!doctype html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mini Gra 3D</title>
+  <link rel="preconnect" href="https://unpkg.com" />
+  <style>
+    :root {
+      color-scheme: light dark;
+      --text: #f7f7f7;
+      --bg: #0e0f1a;
+      --accent: #7cf2c4;
+      --accent-2: #f2d57c;
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+      font-family: "Inter", system-ui, -apple-system, sans-serif;
+    }
+
+    body {
+      background: radial-gradient(circle at 20% 20%, #1d2240 0%, #0e0f1a 45%, #0a0a15 100%);
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      color: var(--text);
+      overflow: hidden;
+    }
+
+    #game-root {
+      position: relative;
+      width: min(1100px, 95vw);
+      aspect-ratio: 16 / 9;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 16px;
+      overflow: hidden;
+      background: linear-gradient(145deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.01));
+      box-shadow:
+        0 40px 120px rgba(0, 0, 0, 0.55),
+        inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+    }
+
+    canvas {
+      width: 100%;
+      height: 100%;
+      display: block;
+    }
+
+    .hud {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      pointer-events: none;
+      padding: 16px 20px;
+    }
+
+    .hud-top {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+
+    .pill {
+      background: rgba(255, 255, 255, 0.06);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 999px;
+      padding: 10px 16px;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      backdrop-filter: blur(8px);
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+    }
+
+    .pill strong {
+      color: var(--accent);
+      letter-spacing: 0.02em;
+    }
+
+    .controls {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+      pointer-events: all;
+    }
+
+    .control-key {
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      border-radius: 10px;
+      padding: 6px 10px;
+      font-weight: 700;
+      color: var(--accent-2);
+    }
+
+    .card {
+      align-self: flex-end;
+      background: rgba(10, 10, 15, 0.7);
+      border-radius: 12px;
+      padding: 14px 16px;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      max-width: 360px;
+      backdrop-filter: blur(10px);
+      box-shadow: 0 10px 25px rgba(0, 0, 0, 0.35);
+    }
+
+    .card h2 {
+      font-size: 18px;
+      margin-bottom: 6px;
+      color: var(--accent);
+    }
+
+    .card p {
+      font-size: 14px;
+      line-height: 1.4;
+      color: rgba(247, 247, 247, 0.85);
+    }
+
+    .footer {
+      font-size: 12px;
+      color: rgba(247, 247, 247, 0.6);
+      text-align: center;
+      letter-spacing: 0.02em;
+    }
+  </style>
+</head>
+<body>
+  <div id="game-root">
+    <canvas id="scene"></canvas>
+    <div class="hud">
+      <div class="hud-top">
+        <div class="pill" id="score-display">Wynik: <strong>0</strong></div>
+        <div class="pill" id="timer-display">Czas: <strong>60</strong> s</div>
+        <div class="controls pill">
+          <span class="control-key">W / ↑</span>
+          <span class="control-key">S / ↓</span>
+          <span class="control-key">A / ←</span>
+          <span class="control-key">D / →</span>
+          <span class="control-key">Spacja</span>
+        </div>
+      </div>
+      <div class="card">
+        <h2>Przyjemna gra 3D</h2>
+        <p>Poruszaj neonowym graczem, zbieraj pulsujące kryształki i wypróbuj skok w niskiej grawitacji. Złap jak najwięcej punktów przed końcem limitu czasu!</p>
+      </div>
+      <div class="footer">Trzymaj okno aktywne aby sterować. Wspierane przez Three.js.</div>
+    </div>
+  </div>
+  <script type="module" src="./src/main.js"></script>
+</body>
+</html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,246 @@
+import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
+import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js';
+
+const canvas = document.getElementById('scene');
+const scoreLabel = document.querySelector('#score-display strong');
+const timerLabel = document.querySelector('#timer-display strong');
+
+const renderer = new THREE.WebGLRenderer({ antialias: true, canvas, alpha: true });
+renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color('#070914');
+scene.fog = new THREE.FogExp2('#070914', 0.025);
+
+const camera = new THREE.PerspectiveCamera(60, 16 / 9, 0.1, 1000);
+camera.position.set(0, 6, 14);
+scene.add(camera);
+
+const controls = new OrbitControls(camera, canvas);
+controls.enableDamping = true;
+controls.target.set(0, 2, 0);
+
+const hemiLight = new THREE.HemisphereLight('#8ef7ff', '#1a1a2a', 0.65);
+scene.add(hemiLight);
+
+const dirLight = new THREE.DirectionalLight('#fff6d9', 1.2);
+dirLight.position.set(4, 8, 6);
+dirLight.castShadow = true;
+scene.add(dirLight);
+
+renderer.shadowMap.enabled = true;
+renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+
+const groundGeometry = new THREE.CylinderGeometry(18, 18, 1, 40, 1, true);
+const groundMaterial = new THREE.MeshStandardMaterial({
+  color: '#11182d',
+  roughness: 0.9,
+  metalness: 0.05,
+});
+const ground = new THREE.Mesh(groundGeometry, groundMaterial);
+ground.receiveShadow = true;
+ground.position.y = -0.6;
+scene.add(ground);
+
+const grid = new THREE.GridHelper(24, 24, '#1ef9ff', '#1f2c46');
+grid.position.y = 0.01;
+scene.add(grid);
+
+const ringGeometry = new THREE.RingGeometry(20.8, 22, 64, 1);
+const ringMaterial = new THREE.MeshBasicMaterial({ color: '#0e1225', side: THREE.DoubleSide, opacity: 0.4, transparent: true });
+const ring = new THREE.Mesh(ringGeometry, ringMaterial);
+ring.rotation.x = -Math.PI / 2;
+ring.position.y = -0.59;
+scene.add(ring);
+
+const playerGeometry = new THREE.BoxGeometry(1.2, 1.2, 1.2);
+const playerMaterial = new THREE.MeshStandardMaterial({
+  color: '#7cf2c4',
+  metalness: 0.2,
+  roughness: 0.3,
+  emissive: '#17443a',
+  emissiveIntensity: 0.5,
+});
+const player = new THREE.Mesh(playerGeometry, playerMaterial);
+player.castShadow = true;
+player.position.y = 1;
+scene.add(player);
+
+const playerVelocity = new THREE.Vector3();
+let onGround = true;
+
+const tokenGeometry = new THREE.OctahedronGeometry(0.6);
+const tokenMaterial = new THREE.MeshStandardMaterial({
+  color: '#f2d57c',
+  metalness: 0.6,
+  roughness: 0.2,
+  emissive: '#3d2f13',
+  emissiveIntensity: 0.8,
+});
+const tokens = [];
+
+function spawnToken() {
+  const mesh = new THREE.Mesh(tokenGeometry, tokenMaterial.clone());
+  mesh.castShadow = true;
+  mesh.position.set(
+    THREE.MathUtils.randFloatSpread(18),
+    THREE.MathUtils.randFloat(0.8, 3),
+    THREE.MathUtils.randFloatSpread(18)
+  );
+  mesh.userData.baseY = mesh.position.y;
+  scene.add(mesh);
+  tokens.push(mesh);
+}
+
+for (let i = 0; i < 8; i += 1) {
+  spawnToken();
+}
+
+const keys = new Set();
+window.addEventListener('keydown', (event) => keys.add(event.code));
+window.addEventListener('keyup', (event) => keys.delete(event.code));
+
+let score = 0;
+let timeLeft = 60;
+let lastTime = performance.now();
+
+function updateHUD() {
+  scoreLabel.textContent = score.toString();
+  timerLabel.textContent = Math.max(0, Math.floor(timeLeft)).toString();
+}
+
+updateHUD();
+
+function resizeRenderer() {
+  const { width, height } = canvas.getBoundingClientRect();
+  renderer.setSize(width, height, false);
+  camera.aspect = width / height;
+  camera.updateProjectionMatrix();
+}
+
+resizeRenderer();
+window.addEventListener('resize', resizeRenderer);
+
+const clock = new THREE.Clock();
+
+function handleMovement(delta) {
+  const acceleration = 18 * delta;
+  const damping = Math.pow(0.88, delta * 60);
+  const maxSpeed = 10;
+
+  if (keys.has('KeyW') || keys.has('ArrowUp')) playerVelocity.z -= acceleration;
+  if (keys.has('KeyS') || keys.has('ArrowDown')) playerVelocity.z += acceleration;
+  if (keys.has('KeyA') || keys.has('ArrowLeft')) playerVelocity.x -= acceleration;
+  if (keys.has('KeyD') || keys.has('ArrowRight')) playerVelocity.x += acceleration;
+
+  if (onGround && (keys.has('Space') || keys.has('ShiftLeft'))) {
+    playerVelocity.y = 8;
+    onGround = false;
+  }
+
+  playerVelocity.y -= 20 * delta;
+
+  playerVelocity.x = THREE.MathUtils.clamp(playerVelocity.x, -maxSpeed, maxSpeed);
+  playerVelocity.z = THREE.MathUtils.clamp(playerVelocity.z, -maxSpeed, maxSpeed);
+
+  player.position.addScaledVector(playerVelocity, delta);
+
+  if (player.position.y <= 1) {
+    player.position.y = 1;
+    playerVelocity.y = 0;
+    onGround = true;
+  }
+
+  playerVelocity.x *= damping;
+  playerVelocity.z *= damping;
+}
+
+function wrapPosition(object, limit = 18) {
+  ['x', 'z'].forEach((axis) => {
+    if (object.position[axis] > limit) object.position[axis] = -limit;
+    if (object.position[axis] < -limit) object.position[axis] = limit;
+  });
+}
+
+function updateTokens(delta) {
+  tokens.forEach((token) => {
+    token.rotation.x += delta * 1.2;
+    token.rotation.y -= delta * 1.8;
+
+    const bounce = Math.sin(clock.elapsedTime * 2 + token.id) * 0.15;
+    token.position.y = token.userData.baseY + bounce;
+
+    const distance = token.position.distanceTo(player.position);
+    if (distance < 1.4) {
+      score += 10;
+      token.position.set(
+        THREE.MathUtils.randFloatSpread(18),
+        THREE.MathUtils.randFloat(0.8, 3),
+        THREE.MathUtils.randFloatSpread(18)
+      );
+      token.userData.baseY = token.position.y;
+      token.material.color.setHSL(Math.random(), 0.6, 0.6);
+      updateHUD();
+    }
+  });
+}
+
+const particles = [];
+const sparkleGeometry = new THREE.SphereGeometry(0.05, 6, 6);
+const sparkleMaterial = new THREE.MeshBasicMaterial({ color: '#7cf2c4' });
+for (let i = 0; i < 120; i += 1) {
+  const mesh = new THREE.Mesh(sparkleGeometry, sparkleMaterial);
+  mesh.position.set(
+    THREE.MathUtils.randFloatSpread(40),
+    THREE.MathUtils.randFloat(4, 18),
+    THREE.MathUtils.randFloatSpread(40)
+  );
+  scene.add(mesh);
+  particles.push(mesh);
+}
+
+function updateParticles(delta) {
+  particles.forEach((particle, index) => {
+    particle.position.y -= 0.5 * delta;
+    if (particle.position.y < 1) particle.position.y = THREE.MathUtils.randFloat(6, 18);
+    particle.position.x += Math.sin(clock.elapsedTime + index) * 0.01;
+  });
+}
+
+function animate(now) {
+  requestAnimationFrame(animate);
+  const delta = clock.getDelta();
+  const elapsed = now - lastTime;
+  lastTime = now;
+
+  if (timeLeft > 0) {
+    timeLeft -= elapsed / 1000;
+    if (timeLeft < 0) timeLeft = 0;
+    updateHUD();
+  }
+
+  handleMovement(delta);
+  wrapPosition(player);
+  updateTokens(delta);
+  updateParticles(delta);
+
+  controls.update();
+  renderer.render(scene, camera);
+}
+
+requestAnimationFrame(animate);
+
+const overlay = document.querySelector('.card p');
+function showStatusMessage(message) {
+  overlay.textContent = message;
+  overlay.style.color = '#ffffff';
+  overlay.animate(
+    [
+      { opacity: 0.4, transform: 'translateY(6px)' },
+      { opacity: 1, transform: 'translateY(0)' },
+    ],
+    { duration: 260, easing: 'ease-out' }
+  );
+}
+
+showStatusMessage('Zbieraj kryształki i nie wypadaj poza pierścień!');


### PR DESCRIPTION
## Summary
- add HTML shell and HUD styling for the 3D mini-game
- implement Three.js scene with controls, collectibles, and timer logic
- document how to launch and play the game in the README

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f3c54f92c83328814cee238c10a40)